### PR TITLE
Handle compile error

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -5,15 +5,21 @@
 var childProcess = require('child_process');
 
 exports.psc = function(files) {
-  return function(k) {
-    return function() {
-      var child = childProcess.spawn("psc", files);
+  return function(ks) {
+    return function(kf) {
+      return function() {
+        var child = childProcess.spawn("psc", files);
 
-      child.stderr.pipe(process.stdout);
+        child.stderr.pipe(process.stdout);
 
-      child.on('close', function() {
-        k();
-      });
+        child.on('close', function(code) {
+          if (code === 0) {
+            ks();
+          } else {
+            kf();
+          }
+        });
+      };
     };
   };
 };

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -16,7 +16,7 @@ import Node.ReadLine
 
 foreign import data PROCESS :: !
 
-foreign import psc :: forall a eff. Array String -> Eff (process :: PROCESS | eff) a -> Eff (process :: PROCESS | eff) Unit
+foreign import psc :: forall a b eff. Array String -> Eff (process :: PROCESS | eff) a -> Eff (process :: PROCESS | eff) b -> Eff (process :: PROCESS | eff) Unit
 
 foreign import execModule :: forall a eff. String -> Eff (process :: PROCESS | eff) a -> Eff (process :: PROCESS | eff) Unit
 
@@ -60,6 +60,7 @@ main = void do
             psc [ "./bower_components/purescript-*/src/**/*.*", "./src/**/*.*", ".psci.purs" ] do
                 execModule "PSCI.Main" do
                   prompt interface
+              $ prompt interface
 
   setPrompt "> " 2 interface
   prompt interface


### PR DESCRIPTION
#1 if the `psc` process exits unsuccessfully skip evaluating and just return to prompt.